### PR TITLE
chore: Perform Upgrade on CI AVR

### DIFF
--- a/.github/workflows/auto-version-release.yml
+++ b/.github/workflows/auto-version-release.yml
@@ -12,7 +12,7 @@ run-name: ${{ github.actor }} run avr workflow-selector
 
 jobs:
   selector: # trigger this on push to main and only when a PR merge.
-    uses: kohirens/version-release/.github/workflows/selector.yml@5.1.7
+    uses: kohirens/version-release/.github/workflows/selector.yml@5.1.8
     name: workflow-selector
     secrets:
       github_write_token: ${{ secrets.GH_WRITE_TOKEN }}


### PR DESCRIPTION
Upgrade Kohirens AVR to version 5.1.8. Remembering that you need to edit the template instead of the generated file is hard.